### PR TITLE
Loosen engines.node

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fabrictech/dynamodb-localhost",
   "version": "0.3.1",
   "engines": {
-    "node": "10.18.0",
+    "node": "^10.18.0",
     "yarn": "^1.9.4"
   },
   "description": "Dynamodb local plugin for devops",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fabrictech/dynamodb-localhost",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "engines": {
     "node": "^10.18.0",
     "yarn": "^1.9.4"


### PR DESCRIPTION
While it's useful to have a baseline node engines restriction, a pinned version (`10.18.0`) makes it difficult for us to bump our node version in Linen. This seems unnecessarily strict - any node 10 version should work, and we can rely on the pinned `engines.node` value in Linen to make sure we're all working with a consistent environment. 

So, we loosen this restriction to allow any minor version >= 10.18.0, and release a new version with this change.

I tested that we are able to properly install this in Linen with both node `10.18.0` and `10.19.0`, and tested that this package behaves as expected in Linen with a subset of our tests.