### PR TITLE
DEVOPS-792/ allow node versions > 10.18.0 for node upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@fabrictech/dynamodb-localhost",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "engines": {
-    "node": "^10.18.0",
+    "node": ">10.18.0",
     "yarn": "^1.9.4"
   },
   "description": "Dynamodb local plugin for devops",


### PR DESCRIPTION
In order to upgrade our node version in linen, we first need to support node versions greater than 10.18.0 in this package.

Testing:
I bumped the version and then linked the package locally to linen.
I then bumped our node version in linen (on my machine, not PR'd yet), and ran tests against dynamoDb local. Tests pass, so the upgrade seems safe. 